### PR TITLE
Stop passing the deprecated `-j` flag to `coffee`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: clean build
 
 build:
 	cat `find ./frontend/ -name *.css` > static/psas/style.css
-	coffee -cj $(STATIC) $(FILES)
+	cat $(FILES) | coffee --compile --stdio > $(STATIC)
 
 clean:
 	rm -f $(STATIC)*


### PR DESCRIPTION
It is deprecated in favor of catting files together and compiling from
stdin.

r? @jameysharp 
